### PR TITLE
Creates filer with NewFiler constructor when loading from file

### DIFF
--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func loadFilerFromFile(fileName string) (c []*Filer) {
 		logger.Fatal("[ERROR] ", err)
 	}
 	for _, b := range fb {
-		c = append(c, &Filer{FilerBase: b})
+		c = append(c, NewFiler(b.Name, b.Host, b.Username, b.Password, b.AvailabilityZone))
 	}
 	return
 }


### PR DESCRIPTION
Fixes #1 --

The `Filer` instance in `loadFilerFromFile(...)` creates the object directly instead of using the `NewFiler` constructor. This results in never initializing the `NetappClient` object, which is then `nil` when it gets invoked to scrape the array in `getVolumeList(...)`.

This change invokes the `NewFiler` constructor in `loadFilerFromFile(...)` in a similar manner to `loadFilerFromEnv(...)`.